### PR TITLE
Implement status API wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use the `GmoCoin` facade to call API endpoints.
 ```php
 use GmoCoin\Facades\GmoCoin;
 
-$response = GmoCoin::request('GET', '/public/v1/status');
+$response = GmoCoin::getStatus();
 ```
 
 The client automatically signs requests when API keys are configured.

--- a/src/GmoCoinClient.php
+++ b/src/GmoCoinClient.php
@@ -55,5 +55,10 @@ class GmoCoinClient
 
         return json_decode($response, true);
     }
+
+    public function getStatus()
+    {
+        return $this->request('GET', '/public/v1/status');
+    }
 }
 


### PR DESCRIPTION
## Summary
- support `/public/v1/status` via `getStatus()`
- document new helper method in README

## Testing
- `composer validate --no-check-all` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68525dcef994833084d5054bd44f76ce