### PR TITLE
Rename FX classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ GMO_COIN_API_SECRET=your_secret
 Use the `GmoCoin` facade to call API endpoints.
 
 ```php
-use GmoCoin\Facades\GmoCoin;
+use GmoCoin\Facades\GmoCoinFx;
 
-$response = GmoCoin::getStatus();
-$ticker   = GmoCoin::getTicker();
-$klines   = GmoCoin::getKlines('USD_JPY', 'ASK', '1min', '20231028');
-$books    = GmoCoin::getOrderBooks('USD_JPY');
-$assets   = GmoCoin::getAssets();
+$response = GmoCoinFx::getStatus();
+$ticker   = GmoCoinFx::getTicker();
+$klines   = GmoCoinFx::getKlines('USD_JPY', 'ASK', '1min', '20231028');
+$books    = GmoCoinFx::getOrderBooks('USD_JPY');
+$assets   = GmoCoinFx::getAssets();
 ```
 
 The client automatically signs requests when API keys are configured.

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
     "extra": {
         "laravel": {
             "providers": [
-                "GmoCoin\\GmoCoinServiceProvider"
+                "GmoCoin\\GmoCoinFxServiceProvider"
             ],
             "aliases": {
-                "GmoCoin": "GmoCoin\\Facades\\GmoCoin"
+                "GmoCoinFx": "GmoCoin\\Facades\\GmoCoinFx"
             }
         }
     },

--- a/src/Facades/GmoCoinFx.php
+++ b/src/Facades/GmoCoinFx.php
@@ -4,11 +4,11 @@ namespace GmoCoin\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-class GmoCoin extends Facade
+class GmoCoinFx extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return \GmoCoin\GmoCoinClient::class;
+        return \GmoCoin\GmoCoinFxClient::class;
     }
 }
 

--- a/src/GmoCoinFxClient.php
+++ b/src/GmoCoinFxClient.php
@@ -2,7 +2,7 @@
 
 namespace GmoCoin;
 
-class GmoCoinClient
+class GmoCoinFxClient
 {
     private $endpoint;
     private $apiKey;

--- a/src/GmoCoinFxServiceProvider.php
+++ b/src/GmoCoinFxServiceProvider.php
@@ -4,15 +4,15 @@ namespace GmoCoin;
 
 use Illuminate\Support\ServiceProvider;
 
-class GmoCoinServiceProvider extends ServiceProvider
+class GmoCoinFxServiceProvider extends ServiceProvider
 {
     public function register()
     {
         $this->mergeConfigFrom(__DIR__.'/../config/gmocoin.php', 'gmocoin');
 
-        $this->app->singleton(GmoCoinClient::class, function ($app) {
+        $this->app->singleton(GmoCoinFxClient::class, function ($app) {
             $config = $app['config']->get('gmocoin');
-            return new GmoCoinClient($config['endpoint'], $config['api_key'], $config['api_secret']);
+            return new GmoCoinFxClient($config['endpoint'], $config['api_key'], $config['api_secret']);
         });
     }
 

--- a/tests/GmoCoinFxClientTest.php
+++ b/tests/GmoCoinFxClientTest.php
@@ -1,7 +1,7 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-class DummyClient extends GmoCoin\GmoCoinClient
+class DummyClient extends GmoCoin\GmoCoinFxClient
 {
     public $calls = [];
     public function request(string $method, string $path, array $params = [], array $body = [])
@@ -11,7 +11,7 @@ class DummyClient extends GmoCoin\GmoCoinClient
     }
 }
 
-class GmoCoinClientTest extends TestCase
+class GmoCoinFxClientTest extends TestCase
 {
     /**
      * @dataProvider apiProvider


### PR DESCRIPTION
## Summary
- rename FX API classes to avoid confusion with future crypto API
- update package provider and facade alias
- adjust documentation and tests

## Testing
- `composer install`
- `./vendor/bin/phpunit --bootstrap tests/bootstrap.php tests`

------
https://chatgpt.com/codex/tasks/task_e_68537bdf52e0833090467be34d6ef113