### PR TITLE
Update credentials handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ php artisan vendor:publish --tag=config
 Set your credentials in `.env`:
 
 ```
-GMO_COIN_API_KEY=your_key
-GMO_COIN_API_SECRET=your_secret
+GMO_COIN_CRYPTO_API_KEY=your_crypto_key
+GMO_COIN_CRYPTO_API_SECRET=your_crypto_secret
+GMO_COIN_FX_API_KEY=your_fx_key
+GMO_COIN_FX_API_SECRET=your_fx_secret
 ```
 
 ## Usage

--- a/config/gmocoin.php
+++ b/config/gmocoin.php
@@ -8,6 +8,13 @@ return [
     // Legacy endpoint key kept for backwards compatibility
     'endpoint' => env('GMO_COIN_ENDPOINT', env('GMO_COIN_CRYPTO_ENDPOINT', 'https://api.coin.z.com')),
 
+    // API credentials for each endpoint
+    'crypto_api_key'    => env('GMO_COIN_CRYPTO_API_KEY', env('GMO_COIN_API_KEY', '')),
+    'crypto_api_secret' => env('GMO_COIN_CRYPTO_API_SECRET', env('GMO_COIN_API_SECRET', '')),
+    'fx_api_key'        => env('GMO_COIN_FX_API_KEY', env('GMO_COIN_API_KEY', '')),
+    'fx_api_secret'     => env('GMO_COIN_FX_API_SECRET', env('GMO_COIN_API_SECRET', '')),
+
+    // Legacy keys kept for backwards compatibility
     'api_key'    => env('GMO_COIN_API_KEY', ''),
     'api_secret' => env('GMO_COIN_API_SECRET', ''),
 ];

--- a/src/GmoCoinFxServiceProvider.php
+++ b/src/GmoCoinFxServiceProvider.php
@@ -13,7 +13,9 @@ class GmoCoinFxServiceProvider extends ServiceProvider
         $this->app->singleton(GmoCoinFxClient::class, function ($app) {
             $config = $app['config']->get('gmocoin');
             $endpoint = $config['fx_endpoint'] ?? $config['endpoint'];
-            return new GmoCoinFxClient($endpoint, $config['api_key'], $config['api_secret']);
+            $apiKey = $config['fx_api_key'] ?? $config['api_key'];
+            $apiSecret = $config['fx_api_secret'] ?? $config['api_secret'];
+            return new GmoCoinFxClient($endpoint, $apiKey, $apiSecret);
         });
     }
 

--- a/src/GmoCoinServiceProvider.php
+++ b/src/GmoCoinServiceProvider.php
@@ -13,7 +13,9 @@ class GmoCoinServiceProvider extends ServiceProvider
         $this->app->singleton(GmoCoinClient::class, function ($app) {
             $config = $app['config']->get('gmocoin');
             $endpoint = $config['crypto_endpoint'] ?? $config['endpoint'];
-            return new GmoCoinClient($endpoint, $config['api_key'], $config['api_secret']);
+            $apiKey = $config['crypto_api_key'] ?? $config['api_key'];
+            $apiSecret = $config['crypto_api_secret'] ?? $config['api_secret'];
+            return new GmoCoinClient($endpoint, $apiKey, $apiSecret);
         });
     }
 


### PR DESCRIPTION
## Summary
- add separate API credentials for crypto and FX endpoints
- update service providers to use the new keys
- document new environment variables in README

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests`

------
https://chatgpt.com/codex/tasks/task_e_6853ad73fc408330b62e912c83a8d7d7