### PR TITLE
Add phpstan static analysis with comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ $assets   = GmoCoin::getAssets();
 
 The client automatically signs requests when API keys are configured.
 
+## Development
+
+Run static analysis to keep the codebase healthy:
+
+```bash
+composer phpstan
+```
+

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
         "ext-json": "*",
         "ext-curl": "*"
     },
+    "scripts": {
+        "phpstan": "phpstan analyse"
+    },
     "autoload": {
         "psr-4": {
             "GmoCoin\\": "src/"
@@ -33,6 +36,7 @@
     },
     "require-dev": {
         "laravel/framework": "^12.19",
-        "phpunit/phpunit": "^10.1.16"
+        "phpunit/phpunit": "^10.1.16",
+        "phpstan/phpstan": "^2.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ce4a26313c97e8687272cb281a1ebf1",
+    "content-hash": "a042d998be9c29e4bf8bdbdb99d14fc2",
     "packages": [],
     "packages-dev": [
         {
@@ -2694,6 +2694,64 @@
                 }
             ],
             "time": "2024-07-20T21:41:07+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/89b5ef665716fa2a52ecd2633f21007a6a349053",
+                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-05-21T20:55:28+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -7211,7 +7269,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -7219,6 +7277,6 @@
         "ext-json": "*",
         "ext-curl": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/config/gmocoin.php
+++ b/config/gmocoin.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Configuration values for the GMO Coin SDK.
+ * These settings control API endpoints and credentials used by the
+ * {@see GmoCoinCryptoClient} and {@see GmoCoinFxClient} classes.
+ */
+
 return [
     // Default endpoints for each API
     'crypto_endpoint' => env('GMO_COIN_CRYPTO_ENDPOINT', 'https://api.coin.z.com'),

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,25 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Parameter \#3 \$value of function curl_setopt expects non\-empty\-string\|null, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/GmoCoinCryptoClient.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 3
+			path: src/GmoCoinCryptoServiceProvider.php
+
+		-
+			message: '#^Parameter \#3 \$value of function curl_setopt expects non\-empty\-string\|null, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/GmoCoinFxClient.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
+			count: 3
+			path: src/GmoCoinFxServiceProvider.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: max
+    paths:
+        - src
+includes:
+    - phpstan-baseline.neon

--- a/src/Facades/GmoCoin.php
+++ b/src/Facades/GmoCoin.php
@@ -4,9 +4,15 @@ namespace GmoCoin\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * Facade exposing {@see \GmoCoin\GmoCoinCryptoClient} methods.
+ */
 class GmoCoin extends Facade
 {
-    protected static function getFacadeAccessor()
+    /**
+     * Resolve the underlying service from the container.
+     */
+    protected static function getFacadeAccessor(): string
     {
         return \GmoCoin\GmoCoinCryptoClient::class;
     }

--- a/src/Facades/GmoCoinFx.php
+++ b/src/Facades/GmoCoinFx.php
@@ -4,9 +4,15 @@ namespace GmoCoin\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * Facade exposing {@see \GmoCoin\GmoCoinFxClient} methods.
+ */
 class GmoCoinFx extends Facade
 {
-    protected static function getFacadeAccessor()
+    /**
+     * Resolve the underlying service from the container.
+     */
+    protected static function getFacadeAccessor(): string
     {
         return \GmoCoin\GmoCoinFxClient::class;
     }

--- a/src/GmoCoinCryptoClient.php
+++ b/src/GmoCoinCryptoClient.php
@@ -2,12 +2,28 @@
 
 namespace GmoCoin;
 
+/**
+ * Client for interacting with the GMO Coin cryptocurrency API.
+ * Handles all HTTP requests to the crypto endpoint.
+ */
 class GmoCoinCryptoClient
 {
-    private $endpoint;
-    private $apiKey;
-    private $apiSecret;
+    /** @var string Base URL for the API */
+    private string $endpoint;
 
+    /** @var string API key used for authenticated requests */
+    private string $apiKey;
+
+    /** @var string API secret used to sign requests */
+    private string $apiSecret;
+
+    /**
+     * Create a new crypto API client.
+     *
+     * @param string $endpoint   Base URL for the crypto API.
+     * @param string $apiKey     Optional API key for private endpoints.
+     * @param string $apiSecret  Optional API secret for private endpoints.
+     */
     public function __construct(string $endpoint, string $apiKey = '', string $apiSecret = '')
     {
         $this->endpoint = rtrim($endpoint, '/');
@@ -15,7 +31,17 @@ class GmoCoinCryptoClient
         $this->apiSecret = $apiSecret;
     }
 
-    public function request(string $method, string $path, array $params = [], array $body = [])
+    /**
+     * Perform an HTTP request against the crypto API.
+     *
+     * @param string               $method HTTP method to use.
+     * @param string               $path   Request path starting with '/'.
+     * @param array<string, mixed> $params Optional query parameters.
+     * @param array<string, mixed> $body   Optional JSON body for POST requests.
+     *
+     * @return array<string, mixed> Decoded JSON response.
+     */
+    public function request(string $method, string $path, array $params = [], array $body = []): array
     {
         $url = $this->endpoint . $path;
         if (!empty($params)) {
@@ -26,7 +52,7 @@ class GmoCoinCryptoClient
             'Content-Type: application/json'
         ];
 
-        $payload = json_encode($body, JSON_UNESCAPED_UNICODE);
+        $payload = json_encode($body, JSON_UNESCAPED_UNICODE) ?: '';
 
         if ($this->apiKey && $this->apiSecret) {
             $timestamp = (string) round(microtime(true) * 1000);
@@ -39,12 +65,16 @@ class GmoCoinCryptoClient
         }
 
         $ch = curl_init($url);
+        if ($ch === false) {
+            throw new \RuntimeException('Unable to initialize curl');
+        }
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
         if ($method !== 'GET') {
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+            $payloadString = (string) $payload;
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $payloadString);
         }
 
         $response = curl_exec($ch);
@@ -52,21 +82,43 @@ class GmoCoinCryptoClient
             throw new \RuntimeException('Curl error: ' . curl_error($ch));
         }
         curl_close($ch);
-
-        return json_decode($response, true);
+        /** @var string $response */
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+        return $decoded;
     }
 
-    public function getStatus()
+    /**
+     * Retrieve the API service status.
+     *
+     * @return array<string, mixed>
+     */
+    public function getStatus(): array
     {
         return $this->request('GET', '/public/v1/status');
     }
 
-    public function getTicker()
+    /**
+     * Retrieve market ticker information.
+     *
+     * @return array<string, mixed>
+     */
+    public function getTicker(): array
     {
         return $this->request('GET', '/public/v1/ticker');
     }
 
-    public function getKlines(string $symbol, string $priceType, string $interval, string $date)
+    /**
+     * Fetch candlestick data for a symbol.
+     *
+     * @param string $symbol     Trading pair.
+     * @param string $priceType  Price type such as ASK/BID.
+     * @param string $interval   Candle interval.
+     * @param string $date       Date in YYYYMMDD format.
+     *
+     * @return array<string, mixed>
+     */
+    public function getKlines(string $symbol, string $priceType, string $interval, string $date): array
     {
         return $this->request('GET', '/public/v1/klines', [
             'symbol'    => $symbol,
@@ -76,14 +128,30 @@ class GmoCoinCryptoClient
         ]);
     }
 
-    public function getOrderBooks(string $symbol)
+    /**
+     * Retrieve the order book for a symbol.
+     *
+     * @param string $symbol Trading pair.
+     *
+     * @return array<string, mixed>
+     */
+    public function getOrderBooks(string $symbol): array
     {
         return $this->request('GET', '/public/v1/orderbooks', [
             'symbol' => $symbol,
         ]);
     }
 
-    public function getTrades(string $symbol, int $page = 1, int $count = 100)
+    /**
+     * Get trade history for a symbol.
+     *
+     * @param string $symbol Trading pair.
+     * @param int    $page   Page number for pagination.
+     * @param int    $count  Items per page.
+     *
+     * @return array<string, mixed>
+     */
+    public function getTrades(string $symbol, int $page = 1, int $count = 100): array
     {
         return $this->request('GET', '/public/v1/trades', [
             'symbol' => $symbol,
@@ -92,127 +160,284 @@ class GmoCoinCryptoClient
         ]);
     }
 
-    public function getSymbols()
+    /**
+     * List all tradable symbols.
+     *
+     * @return array<string, mixed>
+     */
+    public function getSymbols(): array
     {
         return $this->request('GET', '/public/v1/symbols');
     }
 
-    public function getMargin()
+    /**
+     * Get account margin information.
+     *
+     * @return array<string, mixed>
+     */
+    public function getMargin(): array
     {
         return $this->request('GET', '/private/v1/account/margin');
     }
 
-    public function getAssets()
+    /**
+     * Fetch current account assets.
+     *
+     * @return array<string, mixed>
+     */
+    public function getAssets(): array
     {
         return $this->request('GET', '/private/v1/account/assets');
     }
 
-    public function getTradingVolume()
+    /**
+     * Retrieve cumulative trading volume.
+     *
+     * @return array<string, mixed>
+     */
+    public function getTradingVolume(): array
     {
         return $this->request('GET', '/private/v1/account/tradingVolume');
     }
 
-    public function getFiatDepositHistory()
+    /**
+     * Get history of fiat deposits.
+     *
+     * @return array<string, mixed>
+     */
+    public function getFiatDepositHistory(): array
     {
         return $this->request('GET', '/private/v1/account/fiatDeposit/history');
     }
 
-    public function getFiatWithdrawalHistory()
+    /**
+     * Get history of fiat withdrawals.
+     *
+     * @return array<string, mixed>
+     */
+    public function getFiatWithdrawalHistory(): array
     {
         return $this->request('GET', '/private/v1/account/fiatWithdrawal/history');
     }
 
-    public function getDepositHistory()
+    /**
+     * Get cryptocurrency deposit history.
+     *
+     * @return array<string, mixed>
+     */
+    public function getDepositHistory(): array
     {
         return $this->request('GET', '/private/v1/account/deposit/history');
     }
 
-    public function getWithdrawalHistory()
+    /**
+     * Get cryptocurrency withdrawal history.
+     *
+     * @return array<string, mixed>
+     */
+    public function getWithdrawalHistory(): array
     {
         return $this->request('GET', '/private/v1/account/withdrawal/history');
     }
 
-    public function getOrders(array $params)
+    /**
+     * Retrieve order information.
+     *
+     * @param array<string, mixed> $params Query parameters.
+     *
+     * @return array<string, mixed>
+     */
+    public function getOrders(array $params): array
     {
         return $this->request('GET', '/private/v1/orders', $params);
     }
 
-    public function getActiveOrders(array $params = [])
+    /**
+     * List active orders.
+     *
+     * @param array<string, mixed> $params Optional query parameters.
+     *
+     * @return array<string, mixed>
+     */
+    public function getActiveOrders(array $params = []): array
     {
         return $this->request('GET', '/private/v1/activeOrders', $params);
     }
 
-    public function getExecutions(array $params)
+    /**
+     * Fetch execution history.
+     *
+     * @param array<string, mixed> $params Query parameters.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExecutions(array $params): array
     {
         return $this->request('GET', '/private/v1/executions', $params);
     }
 
-    public function getLatestExecutions(array $params)
+    /**
+     * Fetch most recent executions.
+     *
+     * @param array<string, mixed> $params Query parameters.
+     *
+     * @return array<string, mixed>
+     */
+    public function getLatestExecutions(array $params): array
     {
         return $this->request('GET', '/private/v1/latestExecutions', $params);
     }
 
-    public function getOpenPositions(array $params = [])
+    /**
+     * Retrieve currently open positions.
+     *
+     * @param array<string, mixed> $params Optional query parameters.
+     *
+     * @return array<string, mixed>
+     */
+    public function getOpenPositions(array $params = []): array
     {
         return $this->request('GET', '/private/v1/openPositions', $params);
     }
 
-    public function getPositionSummary()
+    /**
+     * Get a summary of positions.
+     *
+     * @return array<string, mixed>
+     */
+    public function getPositionSummary(): array
     {
         return $this->request('GET', '/private/v1/positionSummary');
     }
 
-    public function speedOrder(array $body)
+    /**
+     * Send a speed order request.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function speedOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/speedOrder', [], $body);
     }
 
-    public function order(array $body)
+    /**
+     * Place a standard order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function order(array $body): array
     {
         return $this->request('POST', '/private/v1/order', [], $body);
     }
 
-    public function ifdOrder(array $body)
+    /**
+     * Place an IFD order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function ifdOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/ifdOrder', [], $body);
     }
 
-    public function ifoOrder(array $body)
+    /**
+     * Place an IFO order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function ifoOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/ifoOrder', [], $body);
     }
 
-    public function changeOrder(array $body)
+    /**
+     * Amend an existing order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function changeOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/changeOrder', [], $body);
     }
 
-    public function changeOcoOrder(array $body)
+    /**
+     * Amend an existing OCO order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function changeOcoOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/changeOcoOrder', [], $body);
     }
 
-    public function changeIfdOrder(array $body)
+    /**
+     * Amend an existing IFD order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function changeIfdOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/changeIfdOrder', [], $body);
     }
 
-    public function changeIfoOrder(array $body)
+    /**
+     * Amend an existing IFO order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function changeIfoOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/changeIfoOrder', [], $body);
     }
 
-    public function cancelOrders(array $body)
+    /**
+     * Cancel orders by ID.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function cancelOrders(array $body): array
     {
         return $this->request('POST', '/private/v1/cancelOrders', [], $body);
     }
 
-    public function cancelBulkOrder(array $body)
+    /**
+     * Cancel multiple orders at once.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function cancelBulkOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/cancelBulkOrder', [], $body);
     }
 
-    public function closeOrder(array $body)
+    /**
+     * Close an open position.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function closeOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/closeOrder', [], $body);
     }

--- a/src/GmoCoinCryptoServiceProvider.php
+++ b/src/GmoCoinCryptoServiceProvider.php
@@ -4,22 +4,42 @@ namespace GmoCoin;
 
 use Illuminate\Support\ServiceProvider;
 
+/**
+ * Laravel service provider for the crypto client.
+ * Registers the {@see GmoCoinCryptoClient} and publishes the configuration file.
+ */
 class GmoCoinCryptoServiceProvider extends ServiceProvider
 {
-    public function register()
+    /**
+     * Register bindings with the application container.
+     */
+    public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/gmocoin.php', 'gmocoin');
 
-        $this->app->singleton(GmoCoinCryptoClient::class, function ($app) {
-            $config = $app['config']->get('gmocoin');
-            $endpoint = $config['crypto_endpoint'] ?? $config['endpoint'];
-            $apiKey = $config['crypto_api_key'] ?? $config['api_key'];
-            $apiSecret = $config['crypto_api_secret'] ?? $config['api_secret'];
+        $this->app->singleton(GmoCoinCryptoClient::class, function (\Illuminate\Contracts\Foundation\Application $app): GmoCoinCryptoClient {
+            /** @var \Illuminate\Contracts\Config\Repository $configRepo */
+            $configRepo = $app->make('config');
+            /** @var mixed $cfg */
+            $cfg = $configRepo->get('gmocoin');
+            $config = is_array($cfg) ? $cfg : [];
+            $endpoint = is_string($config['crypto_endpoint'] ?? null)
+                ? $config['crypto_endpoint']
+                : (string) ($config['endpoint'] ?? '');
+            $apiKey = is_string($config['crypto_api_key'] ?? null)
+                ? $config['crypto_api_key']
+                : (string) ($config['api_key'] ?? '');
+            $apiSecret = is_string($config['crypto_api_secret'] ?? null)
+                ? $config['crypto_api_secret']
+                : (string) ($config['api_secret'] ?? '');
             return new GmoCoinCryptoClient($endpoint, $apiKey, $apiSecret);
         });
     }
 
-    public function boot()
+    /**
+     * Publish configuration when the application boots.
+     */
+    public function boot(): void
     {
         $path = function_exists('config_path')
             ? config_path('gmocoin.php')

--- a/src/GmoCoinFxClient.php
+++ b/src/GmoCoinFxClient.php
@@ -2,12 +2,28 @@
 
 namespace GmoCoin;
 
+/**
+ * Client for interacting with the GMO Coin FX API.
+ * This class encapsulates all REST requests made to the FX endpoint.
+ */
 class GmoCoinFxClient
 {
-    private $endpoint;
-    private $apiKey;
-    private $apiSecret;
+    /** @var string Base URL for the API */
+    private string $endpoint;
 
+    /** @var string API key used for authenticated requests */
+    private string $apiKey;
+
+    /** @var string API secret used to sign requests */
+    private string $apiSecret;
+
+    /**
+     * Create a new API client instance.
+     *
+     * @param string $endpoint   Base URL for the FX API.
+     * @param string $apiKey     Optional API key for private endpoints.
+     * @param string $apiSecret  Optional API secret for private endpoints.
+     */
     public function __construct(string $endpoint, string $apiKey = '', string $apiSecret = '')
     {
         $this->endpoint = rtrim($endpoint, '/');
@@ -15,7 +31,17 @@ class GmoCoinFxClient
         $this->apiSecret = $apiSecret;
     }
 
-    public function request(string $method, string $path, array $params = [], array $body = [])
+    /**
+     * Perform a HTTP request against the FX API.
+     *
+     * @param string               $method HTTP method to use.
+     * @param string               $path   Request path starting with '/'.
+     * @param array<string, mixed> $params Optional query parameters.
+     * @param array<string, mixed> $body   Optional JSON body for POST requests.
+     *
+     * @return array<string, mixed> Decoded JSON response from the API.
+     */
+    public function request(string $method, string $path, array $params = [], array $body = []): array
     {
         $url = $this->endpoint . $path;
         if (!empty($params)) {
@@ -26,7 +52,7 @@ class GmoCoinFxClient
             'Content-Type: application/json'
         ];
 
-        $payload = json_encode($body, JSON_UNESCAPED_UNICODE);
+        $payload = json_encode($body, JSON_UNESCAPED_UNICODE) ?: '';
 
         if ($this->apiKey && $this->apiSecret) {
             $timestamp = (string) round(microtime(true) * 1000);
@@ -39,12 +65,16 @@ class GmoCoinFxClient
         }
 
         $ch = curl_init($url);
+        if ($ch === false) {
+            throw new \RuntimeException('Unable to initialize curl');
+        }
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
         if ($method !== 'GET') {
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+            $payloadString = (string) $payload;
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $payloadString);
         }
 
         $response = curl_exec($ch);
@@ -52,21 +82,43 @@ class GmoCoinFxClient
             throw new \RuntimeException('Curl error: ' . curl_error($ch));
         }
         curl_close($ch);
-
-        return json_decode($response, true);
+        /** @var string $response */
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+        return $decoded;
     }
 
-    public function getStatus()
+    /**
+     * Retrieve the API service status.
+     *
+     * @return array<string, mixed>
+     */
+    public function getStatus(): array
     {
         return $this->request('GET', '/public/v1/status');
     }
 
-    public function getTicker()
+    /**
+     * Retrieve market ticker information.
+     *
+     * @return array<string, mixed>
+     */
+    public function getTicker(): array
     {
         return $this->request('GET', '/public/v1/ticker');
     }
 
-    public function getKlines(string $symbol, string $priceType, string $interval, string $date)
+    /**
+     * Fetch candlestick data for a symbol.
+     *
+     * @param string $symbol     Trading pair.
+     * @param string $priceType  Price type such as ASK/BID.
+     * @param string $interval   Candle interval.
+     * @param string $date       Date in YYYYMMDD format.
+     *
+     * @return array<string, mixed>
+     */
+    public function getKlines(string $symbol, string $priceType, string $interval, string $date): array
     {
         return $this->request('GET', '/public/v1/klines', [
             'symbol'    => $symbol,
@@ -76,14 +128,30 @@ class GmoCoinFxClient
         ]);
     }
 
-    public function getOrderBooks(string $symbol)
+    /**
+     * Retrieve the order book for a symbol.
+     *
+     * @param string $symbol Trading pair.
+     *
+     * @return array<string, mixed>
+     */
+    public function getOrderBooks(string $symbol): array
     {
         return $this->request('GET', '/public/v1/orderbooks', [
             'symbol' => $symbol,
         ]);
     }
 
-    public function getTrades(string $symbol, int $page = 1, int $count = 100)
+    /**
+     * Get trade history for a symbol.
+     *
+     * @param string $symbol Trading pair.
+     * @param int    $page   Page number for pagination.
+     * @param int    $count  Items per page.
+     *
+     * @return array<string, mixed>
+     */
+    public function getTrades(string $symbol, int $page = 1, int $count = 100): array
     {
         return $this->request('GET', '/public/v1/trades', [
             'symbol' => $symbol,
@@ -92,127 +160,284 @@ class GmoCoinFxClient
         ]);
     }
 
-    public function getSymbols()
+    /**
+     * List all tradable symbols.
+     *
+     * @return array<string, mixed>
+     */
+    public function getSymbols(): array
     {
         return $this->request('GET', '/public/v1/symbols');
     }
 
-    public function getMargin()
+    /**
+     * Get account margin information.
+     *
+     * @return array<string, mixed>
+     */
+    public function getMargin(): array
     {
         return $this->request('GET', '/private/v1/account/margin');
     }
 
-    public function getAssets()
+    /**
+     * Fetch current account assets.
+     *
+     * @return array<string, mixed>
+     */
+    public function getAssets(): array
     {
         return $this->request('GET', '/private/v1/account/assets');
     }
 
-    public function getTradingVolume()
+    /**
+     * Retrieve cumulative trading volume.
+     *
+     * @return array<string, mixed>
+     */
+    public function getTradingVolume(): array
     {
         return $this->request('GET', '/private/v1/account/tradingVolume');
     }
 
-    public function getFiatDepositHistory()
+    /**
+     * Get history of fiat deposits.
+     *
+     * @return array<string, mixed>
+     */
+    public function getFiatDepositHistory(): array
     {
         return $this->request('GET', '/private/v1/account/fiatDeposit/history');
     }
 
-    public function getFiatWithdrawalHistory()
+    /**
+     * Get history of fiat withdrawals.
+     *
+     * @return array<string, mixed>
+     */
+    public function getFiatWithdrawalHistory(): array
     {
         return $this->request('GET', '/private/v1/account/fiatWithdrawal/history');
     }
 
-    public function getDepositHistory()
+    /**
+     * Get cryptocurrency deposit history.
+     *
+     * @return array<string, mixed>
+     */
+    public function getDepositHistory(): array
     {
         return $this->request('GET', '/private/v1/account/deposit/history');
     }
 
-    public function getWithdrawalHistory()
+    /**
+     * Get cryptocurrency withdrawal history.
+     *
+     * @return array<string, mixed>
+     */
+    public function getWithdrawalHistory(): array
     {
         return $this->request('GET', '/private/v1/account/withdrawal/history');
     }
 
-    public function getOrders(array $params)
+    /**
+     * Retrieve order information.
+     *
+     * @param array<string, mixed> $params Query parameters.
+     *
+     * @return array<string, mixed>
+     */
+    public function getOrders(array $params): array
     {
         return $this->request('GET', '/private/v1/orders', $params);
     }
 
-    public function getActiveOrders(array $params = [])
+    /**
+     * List active orders.
+     *
+     * @param array<string, mixed> $params Optional query parameters.
+     *
+     * @return array<string, mixed>
+     */
+    public function getActiveOrders(array $params = []): array
     {
         return $this->request('GET', '/private/v1/activeOrders', $params);
     }
 
-    public function getExecutions(array $params)
+    /**
+     * Fetch execution history.
+     *
+     * @param array<string, mixed> $params Query parameters.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExecutions(array $params): array
     {
         return $this->request('GET', '/private/v1/executions', $params);
     }
 
-    public function getLatestExecutions(array $params)
+    /**
+     * Fetch most recent executions.
+     *
+     * @param array<string, mixed> $params Query parameters.
+     *
+     * @return array<string, mixed>
+     */
+    public function getLatestExecutions(array $params): array
     {
         return $this->request('GET', '/private/v1/latestExecutions', $params);
     }
 
-    public function getOpenPositions(array $params = [])
+    /**
+     * Retrieve currently open positions.
+     *
+     * @param array<string, mixed> $params Optional query parameters.
+     *
+     * @return array<string, mixed>
+     */
+    public function getOpenPositions(array $params = []): array
     {
         return $this->request('GET', '/private/v1/openPositions', $params);
     }
 
-    public function getPositionSummary()
+    /**
+     * Get a summary of positions.
+     *
+     * @return array<string, mixed>
+     */
+    public function getPositionSummary(): array
     {
         return $this->request('GET', '/private/v1/positionSummary');
     }
 
-    public function speedOrder(array $body)
+    /**
+     * Send a speed order request.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function speedOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/speedOrder', [], $body);
     }
 
-    public function order(array $body)
+    /**
+     * Place a standard order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function order(array $body): array
     {
         return $this->request('POST', '/private/v1/order', [], $body);
     }
 
-    public function ifdOrder(array $body)
+    /**
+     * Place an IFD order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function ifdOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/ifdOrder', [], $body);
     }
 
-    public function ifoOrder(array $body)
+    /**
+     * Place an IFO order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function ifoOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/ifoOrder', [], $body);
     }
 
-    public function changeOrder(array $body)
+    /**
+     * Amend an existing order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function changeOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/changeOrder', [], $body);
     }
 
-    public function changeOcoOrder(array $body)
+    /**
+     * Amend an existing OCO order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function changeOcoOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/changeOcoOrder', [], $body);
     }
 
-    public function changeIfdOrder(array $body)
+    /**
+     * Amend an existing IFD order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function changeIfdOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/changeIfdOrder', [], $body);
     }
 
-    public function changeIfoOrder(array $body)
+    /**
+     * Amend an existing IFO order.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function changeIfoOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/changeIfoOrder', [], $body);
     }
 
-    public function cancelOrders(array $body)
+    /**
+     * Cancel orders by ID.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function cancelOrders(array $body): array
     {
         return $this->request('POST', '/private/v1/cancelOrders', [], $body);
     }
 
-    public function cancelBulkOrder(array $body)
+    /**
+     * Cancel multiple orders at once.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function cancelBulkOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/cancelBulkOrder', [], $body);
     }
 
-    public function closeOrder(array $body)
+    /**
+     * Close an open position.
+     *
+     * @param array<string, mixed> $body Request payload.
+     *
+     * @return array<string, mixed>
+     */
+    public function closeOrder(array $body): array
     {
         return $this->request('POST', '/private/v1/closeOrder', [], $body);
     }

--- a/src/GmoCoinFxServiceProvider.php
+++ b/src/GmoCoinFxServiceProvider.php
@@ -4,22 +4,43 @@ namespace GmoCoin;
 
 use Illuminate\Support\ServiceProvider;
 
+/**
+ * Laravel service provider for the FX client.
+ * Registers the {@see GmoCoinFxClient} in the container and publishes
+ * the configuration file.
+ */
 class GmoCoinFxServiceProvider extends ServiceProvider
 {
-    public function register()
+    /**
+     * Register bindings with the application container.
+     */
+    public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/gmocoin.php', 'gmocoin');
 
-        $this->app->singleton(GmoCoinFxClient::class, function ($app) {
-            $config = $app['config']->get('gmocoin');
-            $endpoint = $config['fx_endpoint'] ?? $config['endpoint'];
-            $apiKey = $config['fx_api_key'] ?? $config['api_key'];
-            $apiSecret = $config['fx_api_secret'] ?? $config['api_secret'];
+        $this->app->singleton(GmoCoinFxClient::class, function (\Illuminate\Contracts\Foundation\Application $app): GmoCoinFxClient {
+            /** @var \Illuminate\Contracts\Config\Repository $configRepo */
+            $configRepo = $app->make('config');
+            /** @var mixed $cfg */
+            $cfg = $configRepo->get('gmocoin');
+            $config = is_array($cfg) ? $cfg : [];
+            $endpoint = is_string($config['fx_endpoint'] ?? null)
+                ? $config['fx_endpoint']
+                : (string) ($config['endpoint'] ?? '');
+            $apiKey = is_string($config['fx_api_key'] ?? null)
+                ? $config['fx_api_key']
+                : (string) ($config['api_key'] ?? '');
+            $apiSecret = is_string($config['fx_api_secret'] ?? null)
+                ? $config['fx_api_secret']
+                : (string) ($config['api_secret'] ?? '');
             return new GmoCoinFxClient($endpoint, $apiKey, $apiSecret);
         });
     }
 
-    public function boot()
+    /**
+     * Publish configuration when the application boots.
+     */
+    public function boot(): void
     {
         $path = function_exists('config_path')
             ? config_path('gmocoin.php')

--- a/tests/GmoCoinCryptoClientTest.php
+++ b/tests/GmoCoinCryptoClientTest.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\TestCase;
 class DummyCryptoClient extends GmoCoin\GmoCoinCryptoClient
 {
     public $calls = [];
-    public function request(string $method, string $path, array $params = [], array $body = [])
+    public function request(string $method, string $path, array $params = [], array $body = []): array
     {
         $this->calls[] = [$method, $path, $params, $body];
         return ['ok' => true];

--- a/tests/GmoCoinFxClientTest.php
+++ b/tests/GmoCoinFxClientTest.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\TestCase;
 class DummyFxClient extends GmoCoin\GmoCoinFxClient
 {
     public $calls = [];
-    public function request(string $method, string $path, array $params = [], array $body = [])
+    public function request(string $method, string $path, array $params = [], array $body = []): array
     {
         $this->calls[] = [$method, $path, $params, $body];
         return ['ok' => true];


### PR DESCRIPTION
## Summary
- document development tools in README
- add phpstan and baseline config
- document facades, clients and service providers
- implement return types and typed properties
- make tests compatible with new signatures

## Testing
- `composer phpstan`
- `vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_686c7a28bb888330815205c8a1d7d9b4